### PR TITLE
Feat: 댓글 글자수 유효성 검증 어노테이션 추가

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -25,7 +27,7 @@ public class CommentController {
      * @return 저장된 댓글의 id
      */
     @PostMapping("/user/comments")
-    public ResponseEntity<?> saveComment(@RequestBody CommentCreateRequestDto commentCreateRequestDto,
+    public ResponseEntity<?> saveComment(@RequestBody @Validated CommentCreateRequestDto commentCreateRequestDto,
                                          @AuthenticationPrincipal UserDetails user) {
         String username = user.getUsername();
         commentService.createComment(commentCreateRequestDto, username);

--- a/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
@@ -8,9 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -27,7 +27,7 @@ public class CommentController {
      * @return 저장된 댓글의 id
      */
     @PostMapping("/user/comments")
-    public ResponseEntity<?> saveComment(@RequestBody @Validated CommentCreateRequestDto commentCreateRequestDto,
+    public ResponseEntity<?> saveComment(@RequestBody @Valid CommentCreateRequestDto commentCreateRequestDto,
                                          @AuthenticationPrincipal UserDetails user) {
         String username = user.getUsername();
         commentService.createComment(commentCreateRequestDto, username);
@@ -53,7 +53,7 @@ public class CommentController {
      */
     @PutMapping("/user/comments/{id}")
     public ResponseEntity<?> editComment(@PathVariable Long id,
-                                         @RequestBody @Validated CommentEditRequestDto commentEditRequestDto) {
+                                         @RequestBody @Valid CommentEditRequestDto commentEditRequestDto) {
         commentService.updateComment(id, commentEditRequestDto);
         return ResponseEntity.ok().body("수정 성공");
     }

--- a/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
@@ -53,7 +53,7 @@ public class CommentController {
      */
     @PutMapping("/user/comments/{id}")
     public ResponseEntity<?> editComment(@PathVariable Long id,
-                                         @RequestBody CommentEditRequestDto commentEditRequestDto) {
+                                         @RequestBody @Validated CommentEditRequestDto commentEditRequestDto) {
         commentService.updateComment(id, commentEditRequestDto);
         return ResponseEntity.ok().body("수정 성공");
     }

--- a/src/main/java/com/teamharmony/newscommunity/comments/dto/CommentCreateRequestDto.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/dto/CommentCreateRequestDto.java
@@ -4,12 +4,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.Size;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Setter
 @Getter
 public class CommentCreateRequestDto {
+    @Size(max = 300, message = "글자수 초과")
     private String content;
+
     private String newsId;
 }

--- a/src/main/java/com/teamharmony/newscommunity/comments/dto/CommentEditRequestDto.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/dto/CommentEditRequestDto.java
@@ -5,10 +5,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.Size;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Setter
 @Getter
 public class CommentEditRequestDto {
+    @Size(max = 300, message = "글자수 초과")
     private String content;
 }

--- a/src/main/java/com/teamharmony/newscommunity/comments/entity/Comment.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/entity/Comment.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @AllArgsConstructor
@@ -23,6 +24,7 @@ public class Comment extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private Long commentId;
+    @Size(max = 300, message = "글자수 초과")
     private String content;
     private String newsId;
 


### PR DESCRIPTION
- 댓글 글자 수가 300자가 넘어가면 유효성 검증을 통과하지 못 하게 하는 어노테이션을 추가했습니다. 

Fixed: #71 