### PR TITLE
users패키지에서 인증, 인가 관련 부분 분리

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/auth/config/security/AuthConstants.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/config/security/AuthConstants.java
@@ -1,4 +1,4 @@
-package com.teamharmony.newscommunity.security;
+package com.teamharmony.newscommunity.auth.config.security;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/teamharmony/newscommunity/auth/config/security/SecurityConfig.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/config/security/SecurityConfig.java
@@ -1,8 +1,8 @@
-package com.teamharmony.newscommunity.security;
+package com.teamharmony.newscommunity.auth.config.security;
 
-import com.teamharmony.newscommunity.filter.CustomAuthenticationFilter;
-import com.teamharmony.newscommunity.filter.CustomAuthorizationFilter;
-import com.teamharmony.newscommunity.users.repository.TokensRepository;
+import com.teamharmony.newscommunity.auth.filter.CustomAuthenticationFilter;
+import com.teamharmony.newscommunity.auth.filter.CustomAuthorizationFilter;
+import com.teamharmony.newscommunity.auth.repository.TokensRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/teamharmony/newscommunity/auth/controller/AuthController.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.teamharmony.newscommunity.auth.controller;
+
+import com.teamharmony.newscommunity.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class AuthController {
+	private final AuthService authService;
+	
+	/**
+	 * 접근 토큰, 갱신 토큰 갱신
+	 *
+	 * @see				AuthService#refreshToken
+	 */
+	@GetMapping("/token/refresh")
+	public ResponseEntity<String>refreshToken(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentContextPath().path("/api/token/refresh").toUriString());
+		return ResponseEntity.ok().body(authService.refreshToken(request, response));
+	}
+	
+	/**
+	 * 로그아웃
+	 *
+	 * @param 		user 인증된 사용자 정보
+	 * @see				AuthService#signOut
+	 */
+	@GetMapping("/user/signout")
+	public ResponseEntity<Void> signOut(HttpServletRequest request, HttpServletResponse response, @AuthenticationPrincipal UserDetails user) {
+		authService.signOut(request, response, user.getUsername());
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/teamharmony/newscommunity/auth/entity/Tokens.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/entity/Tokens.java
@@ -1,4 +1,4 @@
-package com.teamharmony.newscommunity.users.entity;
+package com.teamharmony.newscommunity.auth.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/teamharmony/newscommunity/auth/filter/CustomAuthenticationFilter.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/filter/CustomAuthenticationFilter.java
@@ -1,10 +1,10 @@
-package com.teamharmony.newscommunity.filter;
+package com.teamharmony.newscommunity.auth.filter;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.teamharmony.newscommunity.users.entity.Tokens;
-import com.teamharmony.newscommunity.users.repository.TokensRepository;
+import com.teamharmony.newscommunity.auth.entity.Tokens;
+import com.teamharmony.newscommunity.auth.repository.TokensRepository;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/src/main/java/com/teamharmony/newscommunity/auth/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/filter/CustomAuthorizationFilter.java
@@ -1,12 +1,12 @@
-package com.teamharmony.newscommunity.filter;
+package com.teamharmony.newscommunity.auth.filter;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.teamharmony.newscommunity.security.AuthConstants;
-import com.teamharmony.newscommunity.users.repository.TokensRepository;
+import com.teamharmony.newscommunity.auth.config.security.AuthConstants;
+import com.teamharmony.newscommunity.auth.repository.TokensRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/src/main/java/com/teamharmony/newscommunity/auth/repository/TokensRepository.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/repository/TokensRepository.java
@@ -1,7 +1,7 @@
-package com.teamharmony.newscommunity.users.repository;
+package com.teamharmony.newscommunity.auth.repository;
 
 
-import com.teamharmony.newscommunity.users.entity.Tokens;
+import com.teamharmony.newscommunity.auth.entity.Tokens;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TokensRepository extends JpaRepository<Tokens, Long> {

--- a/src/main/java/com/teamharmony/newscommunity/auth/service/AuthService.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/service/AuthService.java
@@ -1,0 +1,142 @@
+package com.teamharmony.newscommunity.auth.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamharmony.newscommunity.auth.entity.Tokens;
+import com.teamharmony.newscommunity.auth.repository.TokensRepository;
+import com.teamharmony.newscommunity.users.entity.Role;
+import com.teamharmony.newscommunity.users.entity.User;
+import com.teamharmony.newscommunity.users.entity.UserRole;
+import com.teamharmony.newscommunity.users.repository.UserRepository;
+import com.teamharmony.newscommunity.users.repository.UserRoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.teamharmony.newscommunity.auth.util.CookieUtil.getRefCookie;
+import static com.teamharmony.newscommunity.auth.util.CookieUtil.removeRefCookie;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+	private final TokensRepository tokensRepository;
+	private final UserRepository userRepository;
+	private final UserRoleRepository userRoleRepository;
+	
+	
+	public String refreshToken(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		// 클라이언트가 쿠키에 리프레쉬 토큰을 갖고 있는지 확인
+		String refCookie = getRefCookie(request);
+		
+		// 쿠키가 있으면 DB에 있는지 재확인하고 새로운 쿠키를 DB 저장 후 발급
+		if (refCookie != null) {
+			try {
+				Algorithm algorithm = Algorithm.HMAC256("secret".getBytes());
+				JWTVerifier verifier = JWT.require(algorithm)
+				                          .build();
+				DecodedJWT decodedJWT = verifier.verify(refCookie);
+				String username = decodedJWT.getSubject();
+				String allowedToken = getTokens(username).getRefreshToken();
+				if(!allowedToken.equals(refCookie))throw new IllegalArgumentException("Token not found");
+				// Once we get the username, we need to load that user
+				// use the user(loaded using the username) to create a new token( using the refresh token)
+				User user = userRepository.findByUsername(username);
+				Collection<UserRole> userRole = userRoleRepository.findByUser(user);
+				Collection<Role> roles = new ArrayList<>();
+				userRole.forEach(r -> roles.add(r.getRole()));
+				String access_token = JWT.create()
+				                         .withSubject(user.getUsername())
+				                         .withExpiresAt(new Date(System.currentTimeMillis() + 16*60*60*1000)) // 테스트를 위해 16시간으로 설정
+				                         .withClaim("roles", roles.stream().map(Role::getName).map(Enum::toString).collect(Collectors.toList()))
+				                         .sign(algorithm);
+				String refresh_token = JWT.create()
+				                          .withSubject(user.getUsername())
+				                          .withExpiresAt(new Date(System.currentTimeMillis() + 7*24*60*60*1000))
+				                          .sign(algorithm);
+				updateTokens(username, access_token, refresh_token);
+				
+				ResponseCookie refresh = ResponseCookie.from("ref_uid", refresh_token)
+				                                       .maxAge(7*24*60*60*1000) // 밀리세컨인지 확인해야됨
+				                                       .httpOnly(true)
+				                                       .secure(true)
+				                                       .sameSite("None")
+				                                       .path("/")
+				                                       .build();
+				response.setHeader(SET_COOKIE, refresh.toString());
+				response.setHeader("token", access_token);
+				response.setContentType(APPLICATION_JSON_VALUE);
+			} catch (Exception e) {
+				removeRefCookie(response);
+				setError(response, e.getMessage());
+			}
+		} else {
+			removeRefCookie(response);
+			setError(response, "Refresh token is missing");
+		}
+		return "success";
+	}
+	
+	// 에러 발생시 헤더와 output 설정
+	private void setError(HttpServletResponse response, String msg) throws IOException {
+		response.setHeader("error", msg);
+		response.setStatus(FORBIDDEN.value());
+		Map<String, String> error = new HashMap<>();
+		error.put("error", msg);
+		response.setContentType(APPLICATION_JSON_VALUE);
+		new ObjectMapper().writeValue(response.getOutputStream(), error);
+	}
+	
+	/**
+	 * 로그아웃
+	 *
+	 * @param 		username 인증된 사용자 ID
+	 */
+	public void signOut(HttpServletRequest request, HttpServletResponse response, String username) {
+		// 클라이언트가 쿠키에 리프레쉬 토큰을 갖고 있는지 확인
+		String refCookie = getRefCookie(request);
+		// 쿠키가 있으면 삭제
+		if (refCookie != null) {
+			removeRefCookie(response);
+		}
+		// DB에 저장된 토큰 값 공백 처리
+		updateTokens(username, "", "");
+	}
+	
+	/**
+	 * 사용자의 허용 토큰 정보 조회
+	 *
+	 * @param 		username 조회할 사용자 ID
+	 * @return 		사용자의 허용 토큰 정보
+	 */
+	private Tokens getTokens(String username) {
+		log.info("Fetching tokens of user {}", username);
+		return tokensRepository.findByUsername(username);
+	}
+	
+	/**
+	 * 토큰 값 변경
+	 *
+	 * @param username      해당 사용자 ID
+	 * @param access_token  허용된 접근 토큰 값
+	 * @param refresh_token 허용된 갱신 토큰 값
+	 */
+	private void updateTokens(String username, String access_token, String refresh_token) {
+		Tokens tokens = getTokens(username);
+		tokens.update(access_token, refresh_token);
+		tokensRepository.save(tokens);
+	}
+}

--- a/src/main/java/com/teamharmony/newscommunity/auth/util/CookieUtil.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/util/CookieUtil.java
@@ -1,0 +1,35 @@
+package com.teamharmony.newscommunity.auth.util;
+
+import org.springframework.http.ResponseCookie;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+public class CookieUtil {
+	// 리프레쉬 쿠키값 가져오기
+	public static String getRefCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		Cookie cookie = null;
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie value : cookies) {
+				if (value.getName()
+				         .equals("ref_uid")) {
+					cookie = value;
+				}
+			}
+		}
+		return cookie.getValue();
+	}
+	
+	// 리프레쉬 쿠키 삭제(만료시간 0으로 설정)
+	public static void removeRefCookie(HttpServletResponse response) {
+		ResponseCookie refresh = ResponseCookie.from("ref_uid", "")
+		                                       .maxAge(0)
+		                                       .path("/")
+		                                       .build();
+		response.setHeader(SET_COOKIE, refresh.toString());
+	}
+}

--- a/src/main/java/com/teamharmony/newscommunity/users/controller/UserController.java
+++ b/src/main/java/com/teamharmony/newscommunity/users/controller/UserController.java
@@ -1,10 +1,5 @@
 package com.teamharmony.newscommunity.users.controller;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.JWTVerifier;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.DecodedJWT;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teamharmony.newscommunity.users.dto.UserResponseDto;
 import com.teamharmony.newscommunity.users.service.UserService;
 import com.teamharmony.newscommunity.users.vo.ProfileVO;
@@ -14,29 +9,17 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.HibernateException;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import java.io.IOException;
 import java.net.URI;
-import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.springframework.http.HttpHeaders.SET_COOKIE;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * 사용자 관련 요청을 처리
@@ -175,117 +158,6 @@ public class UserController {
 		String username = user.getUsername();
 		URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentContextPath().path("/api/user/update_profile").toUriString());
 		return ResponseEntity.created(uri).body(userService.updateProfile(username, profile));
-	}
-	
-	/**
-	 * 접근 토큰, 갱신 토큰 갱신
-	 *
-	 * @see				UserService#getTokens
-	 * @see				UserService#getUser
-	 * @see				UserService#getRoles
-	 * @see				UserService#updateTokens
-	 */
-	@GetMapping("/token/refresh")
-	public void refreshToken(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		// 클라이언트가 쿠키에 리프레쉬 토큰을 갖고 있는지 확인
-		String refCookie = getRefCookie(request);
-		
-		// 쿠키가 있으면 DB에 있는지 재확인하고 새로운 쿠키를 DB 저장 후 발급
-		if (refCookie != null) {
-			try {
-				Algorithm algorithm = Algorithm.HMAC256("secret".getBytes());
-				JWTVerifier verifier = JWT.require(algorithm)
-				                          .build();
-				DecodedJWT decodedJWT = verifier.verify(refCookie);
-				String username = decodedJWT.getSubject();
-				String allowedToken = userService.getTokens(username).getRefreshToken();
-				if(!allowedToken.equals(refCookie))throw new IllegalArgumentException("Token not found");
-				// Once we get the username, we need to load that user
-				// use the user(loaded using the username) to create a new token( using the refresh token)
-				User user = userService.getUser(username);
-				String access_token = JWT.create()
-				                         .withSubject(user.getUsername())
-				                         .withExpiresAt(new Date(System.currentTimeMillis() + 16*60*60*1000)) // 테스트를 위해 16시간으로 설정
-				                         .withClaim("roles", userService.getRoles(user).stream().map(Role::getName).map(Enum::toString).collect(Collectors.toList()))
-				                         .sign(algorithm);
-				String refresh_token = JWT.create()
-				                          .withSubject(user.getUsername())
-				                          .withExpiresAt(new Date(System.currentTimeMillis() + 7*24*60*60*1000))
-				                          .sign(algorithm);
-				userService.updateTokens(username, access_token, refresh_token);
-				
-				ResponseCookie refresh = ResponseCookie.from("ref_uid", refresh_token)
-				                                       .maxAge(7*24*60*60*1000) // 밀리세컨인지 확인해야됨
-				                                       .httpOnly(true)
-				                                       .secure(true)
-				                                       .sameSite("None")
-				                                       .path("/")
-				                                       .build();
-				response.setHeader(SET_COOKIE, refresh.toString());
-				response.setHeader("token", access_token);
-				response.setContentType(APPLICATION_JSON_VALUE);
-				new ObjectMapper().writeValue(response.getOutputStream(), "success");
-			} catch (Exception e) {
-				removeRefCookie(response);
-				setError(response, e.getMessage());
-			}
-		} else {
-			removeRefCookie(response);
-			setError(response, "Refresh token is missing");
-		}
-	}
-	
-	/**
-	 * 로그아웃
-	 *
-	 * @param 		user 인증된 사용자 정보
-	 * @see				UserService#updateTokens
-	 */
-	@GetMapping("/user/signout")
-	public ResponseEntity<Void>signOut(HttpServletRequest request, HttpServletResponse response, @AuthenticationPrincipal UserDetails user) {
-// 클라이언트가 쿠키에 리프레쉬 토큰을 갖고 있는지 확인
-		String refCookie = getRefCookie(request);
-		// 쿠키가 있으면 삭제
-		if (refCookie != null) {
-			removeRefCookie(response);
-		}
-		// DB에 저장된 토큰 값 공백 처리
-		userService.updateTokens(user.getUsername(), "", "");
-		return ResponseEntity.ok().build();
-	}
-	
-	// 리프레쉬 쿠키값 가져오기
-	private String getRefCookie(HttpServletRequest request) {
-		Cookie[] cookies = request.getCookies();
-		Cookie cookie = null;
-		if (cookies != null && cookies.length > 0) {
-			for (Cookie value : cookies) {
-				if (value.getName()
-				         .equals("ref_uid")) {
-					cookie = value;
-				}
-			}
-		}
-		return cookie.getValue();
-	}
-	
-	// 리프레쉬 쿠키 삭제(만료시간 0으로 설정)
-	private void removeRefCookie(HttpServletResponse response) {
-		ResponseCookie refresh = ResponseCookie.from("ref_uid", "")
-		                                       .maxAge(0)
-		                                       .path("/")
-		                                       .build();
-		response.setHeader(SET_COOKIE, refresh.toString());
-	}
-	
-	// 에러 발생시 헤더와 output 설정
-	private void setError(HttpServletResponse response, String msg) throws IOException {
-		response.setHeader("error", msg);
-		response.setStatus(FORBIDDEN.value());
-		Map<String, String> error = new HashMap<>();
-		error.put("error", msg);
-		response.setContentType(APPLICATION_JSON_VALUE);
-		new ObjectMapper().writeValue(response.getOutputStream(), error);
 	}
 }
 

--- a/src/main/java/com/teamharmony/newscommunity/users/service/UserService.java
+++ b/src/main/java/com/teamharmony/newscommunity/users/service/UserService.java
@@ -1,7 +1,5 @@
 package com.teamharmony.newscommunity.users.service;
 
-import com.teamharmony.newscommunity.auth.entity.Tokens;
-import com.teamharmony.newscommunity.auth.repository.TokensRepository;
 import com.teamharmony.newscommunity.users.dto.*;
 import com.teamharmony.newscommunity.users.vo.ProfileVO;
 import com.teamharmony.newscommunity.users.entity.*;
@@ -37,8 +35,6 @@ public class UserService implements UserDetailsService {
 	private final RoleRepository roleRepository;
 	private final UserProfileRepository profileRepository;
 	private final UserRoleRepository userRoleRepository;
-	private final TokensRepository tokensRepository;
-	
 	private final PasswordEncoder passwordEncoder;
 	private final FileStore fileStore;
 	
@@ -101,20 +97,6 @@ public class UserService implements UserDetailsService {
 	public void saveRole(Role role) {
 		log.info("Saving new role {} to the database", role.getName());
 		roleRepository.save(role);
-	}
-	
-	/**
-	 * 토큰 값 변경
-	 *
-	 * @param 		username 해당 사용자 ID
-	 * @param 		access_token 허용된 접근 토큰 값
-	 * @param 		refresh_token 허용된 갱신 토큰 값
-	 * @return 		저장된 토큰 정보
-	 */
-	public Tokens updateTokens(String username, String access_token, String refresh_token) {
-		Tokens tokens = getTokens(username);
-		tokens.update(access_token, refresh_token);
-		return tokensRepository.save(tokens);
 	}
 	
 	/**
@@ -243,20 +225,6 @@ public class UserService implements UserDetailsService {
 	}
 	
 	/**
-	 * 사용자가 지닌 권한 정보 조회
-	 *
-	 * @param 		user 조회할 사용자 ID
-	 * @return 		사용자가 지닌 권한 정보
-	 * @see				UserService#getRoles
-	 */
-	public Collection<Role> getRoles(User user) {
-		Collection<UserRole> userRole = userRoleRepository.findByUser(user);
-		Collection<Role> roles = new ArrayList<>();
-		userRole.forEach(r -> roles.add(r.getRole()));
-		return roles;
-	}
-	
-	/**
 	 * 전체 사용자 조회
 	 *
 	 * @return 		전체 사용자 정보
@@ -284,17 +252,6 @@ public class UserService implements UserDetailsService {
 		body.put("link", getProfileImageUrl(username));
 		body.put("profile", profileDto);
 		return body;
-	}
-	
-	/**
-	 * 사용자의 허용 토큰 정보 조회
-	 *
-	 * @param 		username 조회할 사용자 ID
-	 * @return 		사용자의 허용 토큰 정보
-	 */
-	public Tokens getTokens(String username) {
-		log.info("Fetching tokens of user {}", username);
-		return tokensRepository.findByUsername(username);
 	}
 	
 	/**

--- a/src/main/java/com/teamharmony/newscommunity/users/service/UserService.java
+++ b/src/main/java/com/teamharmony/newscommunity/users/service/UserService.java
@@ -1,5 +1,7 @@
 package com.teamharmony.newscommunity.users.service;
 
+import com.teamharmony.newscommunity.auth.entity.Tokens;
+import com.teamharmony.newscommunity.auth.repository.TokensRepository;
 import com.teamharmony.newscommunity.users.dto.*;
 import com.teamharmony.newscommunity.users.vo.ProfileVO;
 import com.teamharmony.newscommunity.users.entity.*;

--- a/src/test/java/com/teamharmony/newscommunity/news/controller/NewsControllerTest.java
+++ b/src/test/java/com/teamharmony/newscommunity/news/controller/NewsControllerTest.java
@@ -6,7 +6,7 @@ import com.teamharmony.newscommunity.common.ApiResponse;
 import com.teamharmony.newscommunity.news.dto.ResponseNewsDetailDTO;
 import com.teamharmony.newscommunity.news.entity.NewsTable;
 import com.teamharmony.newscommunity.news.service.NewsService;
-import com.teamharmony.newscommunity.users.repository.TokensRepository;
+import com.teamharmony.newscommunity.auth.repository.TokensRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
[Refactor]
- auth 패키지를 생성해 filter와 security 그리고 토큰 entity와 repo를 분리했습니다.

[Fix]
- auth 내에 controller와 service를 추가해서 auth와 관련된 부분들을 옮겼습니다.
- 옮기면서 Userservice 내 함수를 쓰던 부분들을 수정했습니다.

Fixed: #79