### PR TITLE
회원 관련 유효성 검증 수정

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/auth/entity/Tokens.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/entity/Tokens.java
@@ -9,6 +9,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.validation.constraints.Pattern;
 
 import static javax.persistence.GenerationType.IDENTITY;
 
@@ -22,6 +23,7 @@ public class Tokens {
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
 	@Column(unique = true, nullable=false)
+	@Pattern(regexp = "(?=.*[a-zA-Z])[-a-zA-Z0-9_.]{2,10}")
 	private String username;
 	@Column(nullable = false)
 	private String accessToken;

--- a/src/main/java/com/teamharmony/newscommunity/users/dto/SignupRequestDto.java
+++ b/src/main/java/com/teamharmony/newscommunity/users/dto/SignupRequestDto.java
@@ -5,16 +5,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.Pattern;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 public class SignupRequestDto {
 	@NotBlank
-	@Size(min = 2, max = 10)
+	@Pattern(regexp = "(?=.*[a-zA-Z])[-a-zA-Z0-9_.]{2,10}")
 	private String username;
-	@NotBlank
-	@Size(min = 8, max = 20)
+	@Pattern(regexp = "(?=.*\\d)(?=.*[a-zA-Z])[0-9a-zA-Z!@#$%^&*]{8,20}")
 	private String password;
 }

--- a/src/main/java/com/teamharmony/newscommunity/users/entity/User.java
+++ b/src/main/java/com/teamharmony/newscommunity/users/entity/User.java
@@ -11,7 +11,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.Pattern;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -28,7 +28,7 @@ public class User  extends Timestamped {
 	@Column(name = "user_id")
 	private Long id;
 	@Column(unique = true, nullable = false)
-	@Size(min = 2, max = 10)
+	@Pattern(regexp = "(?=.*[a-zA-Z])[-a-zA-Z0-9_.]{2,10}")
 	private String username;
 	@Column(nullable = false)
 	@NotBlank


### PR DESCRIPTION
[Feat]
특정 회원에 해당하는 토큰을 저장할 때 username에 유효성 검증 추가

[Fix]
기존에 길이만 검증하던 부분을 정규식으로 검증하도록 변경

Fixd: #82