### PR TITLE
Fix: comment column 크기 수정 

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/comments/entity/Comment.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/entity/Comment.java
@@ -25,6 +25,7 @@ public class Comment extends Timestamped {
     @Id
     private Long commentId;
     @Size(max = 300, message = "글자수 초과")
+    @Column(length = 1000)
     private String content;
     private String newsId;
 


### PR DESCRIPTION
comment 칼럼 크기가 작아서 긴 댓글이 들어가지 않던 것을 수정했습니다.

Fixed: #87 