### PR TITLE
bookmark 도메인 정비 및 예외처리 시범 적용

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/aop/advice/GlobalHandlerException.java
+++ b/src/main/java/com/teamharmony/newscommunity/aop/advice/GlobalHandlerException.java
@@ -1,0 +1,48 @@
+package com.teamharmony.newscommunity.aop.advice;
+
+import com.teamharmony.newscommunity.exception.Error;
+import com.teamharmony.newscommunity.exception.ErrorResponse;
+import com.teamharmony.newscommunity.exception.InvalidRequestException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalHandlerException {
+    @ExceptionHandler(value = { InvalidRequestException.class })
+    public ResponseEntity<Object> handleApiRequestException(InvalidRequestException ex, HttpServletRequest httpServletRequest) {
+        List<Error> errorList = new ArrayList<>();
+
+        String fieldName = "invalid Error";
+        String message = ex.getMessage();
+        String invalidValue = ex.getInvalidValue();
+
+
+        Error errorMessage = new Error();
+        errorMessage.setField(fieldName);
+        errorMessage.setMessage(message);
+        errorMessage.setInvalidValue(invalidValue);
+        errorList.add(errorMessage);
+
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setErrorList(errorList);
+        errorResponse.setMessage(message);
+        errorResponse.setRequestUrl(httpServletRequest.getRequestURI());
+        errorResponse.setStatusCode(HttpStatus.BAD_REQUEST.toString());
+        errorResponse.setResultCode("FAIL");
+        errorResponse.setCode(ex.getCode());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity exception(Exception e){
+        System.out.println(e.getClass().getName());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("");
+    }
+}

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/controller/BookmarkController.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/controller/BookmarkController.java
@@ -29,7 +29,8 @@ public class BookmarkController {
      * @return 해당 뉴스에 대한 사용자의 북마크 여부 (True||False)
      */
     @GetMapping("")
-    public ApiResponse<Boolean> isBookmark(@RequestBody RequestBookmarkDTO requestBookmarkDTO){
+    public ApiResponse<Boolean> isBookmark(@RequestParam String newsId, @RequestParam String userId){
+        RequestBookmarkDTO requestBookmarkDTO = new RequestBookmarkDTO(newsId, userId, null);
         return ApiResponse.success("result", bookmarkService.isBookmarkCheck(requestBookmarkDTO));
     }
 

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/controller/BookmarkController.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/controller/BookmarkController.java
@@ -13,43 +13,44 @@ import org.springframework.web.bind.annotation.*;
 public class BookmarkController {
     private final BookmarkService bookmarkService;
 
-    //1. TODO: 북마크 생성 (req: newsId, userId) use by deatil.html    (res: ApiResponse.success("result", newsID))   //DONE
+    /**
+     * detail.html에서 해당 뉴스의 id와 읽고 있는 userId를 가지고 bookmarkLog를 생성
+     * @param requestBookmarkDTO
+     * @return 생성된 북마크의 식별번호(Id: String, based on UUID4)
+     */
     @PostMapping("")
     public ApiResponse<String> createBookmark(@RequestBody RequestBookmarkDTO requestBookmarkDTO){
-        /* detail.html에서 해당 뉴스의 id와 읽고 있는 userId를 가지고 bookmarkLog를 생성
-            @param: 북마크 생성을 위한 RequestBookmarkDTO (newsId, userId)
-            @return: 생성된 북마크의 식별번호(Id: String, based on UUID4)
-         */
         return ApiResponse.success("result", bookmarkService.createBookmark(requestBookmarkDTO));
     }
 
-    //2. TODO: 북마크 여부 검증(req: newsId, userId) use by detail.html (res: ApiResponse.success("result", newsId))
+    /**
+     * detail.html에서 해당 뉴스의 id와 읽고 있는 userId를 가지고 사용자가 뉴스를 북마크했는지 판별
+     * @param requestBookmarkDTO
+     * @return 해당 뉴스에 대한 사용자의 북마크 여부 (True||False)
+     */
     @GetMapping("")
     public ApiResponse<Boolean> isBookmark(@RequestBody RequestBookmarkDTO requestBookmarkDTO){
-        /* detail.html에서 해당 뉴스의 id와 읽고 있는 userId를 가지고 사용자가 뉴스를 북마크했는지 판별
-            @param: 북마크 여부 판별을 위한 RequestBookmarkDTO (newsId, userId)
-            @return: 해당 뉴스에 대한 사용자의 북마크 여부 (True||False)
-         */
         return ApiResponse.success("result", bookmarkService.isBookmarkCheck(requestBookmarkDTO));
     }
 
-    //3. TODO: 북마크 취소 (req: newId, userId) use by detail.html     (res: ApiResponse.success("result", newsId))
+
+    /**
+     * detail.html에서 해당 뉴스의 id와 읽고 있는 userId를 가지고 사용자가 뉴스를 북마크했는지 판별
+     * @param requestBookmarkDTO
+     * @return 해당 뉴스에 대한 사용자의 북마크 여부 (True||False)
+     */
     @DeleteMapping("")
     public ApiResponse<String> cancel(@RequestBody RequestBookmarkDTO requestBookmarkDTO){
-        /* detail.html에서 해당 뉴스의 id와 읽고 있는 userId를 가지고 사용자가 뉴스를 북마크했는지 판별
-            @param: 북마크 여부 판별을 위한 RequestBookmarkDTO (newsId, userId)
-            @return: 해당 뉴스에 대한 사용자의 북마크 여부 (True||False)
-         */
         return ApiResponse.success("result", bookmarkService.deleteBookmark(requestBookmarkDTO));
     }
 
-    //4. TODO: 북마크 리스트 조회 (req: userId) use by profile.html     (res: ApiResponse.success("result", List<Bookmark>))
+    /**
+     * profile.html에서 보내준 profile userId의 bookmark 일괄 조회
+     * @param userId
+     * @return 해당 유저가 북마킹한 내역인 List<Bookmark>를 리턴
+     */
     @GetMapping("/profiles/{userId}")
     public ApiResponse<ResponseBookmarkDTO> bookmark(@PathVariable String userId){
-        /* profile.html에서 보내준 profile userId의 bookmark 일괄 조회
-            @param: 북마크 검색시 필요한 userId
-            @return: 해당 유저가 북마킹한 내역인 List<Bookmark>를 리턴
-         */
         return ApiResponse.success("result", bookmarkService.selectAllUserBookmark(userId));
     }
 }

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/dto/RequestBookmarkDTO.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/dto/RequestBookmarkDTO.java
@@ -1,8 +1,10 @@
 package com.teamharmony.newscommunity.bookmarks.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class RequestBookmarkDTO {
     private String newsId;
     private String userId;

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/dto/RequestBookmarkDTO.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/dto/RequestBookmarkDTO.java
@@ -6,4 +6,5 @@ import lombok.Getter;
 public class RequestBookmarkDTO {
     private String newsId;
     private String userId;
+    private String title;
 }

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/entity/Bookmarks.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/entity/Bookmarks.java
@@ -27,10 +27,14 @@ public class Bookmarks extends TimestampedOnBookmark {
     @Column(nullable = false, length = 50)
     String userId;      // 해당 뉴스에 접근한 userId
 
+    @Column(nullable = false, length = 50)
+    String title;
+
     @Builder
-    public Bookmarks(RequestBookmarkDTO requestBookmarkDTO){
+    public Bookmarks(String newsId, String userId, String title){
         this.id = UUID.randomUUID().toString();
-        this.newsId = requestBookmarkDTO.getNewsId();
-        this.userId = requestBookmarkDTO.getUserId();
+        this.newsId = newsId;
+        this.userId = userId;
+        this.title = title;
     }
 }

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/repository/BookmarkRepository.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/repository/BookmarkRepository.java
@@ -6,15 +6,15 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+/**북마크 정보를 담을 BookmarkRepository, 아래는 관력 역할
+ * @GET: 북마크 여부 검증, 해당 user의 북마크 리스트 조회          :(/api/bookmarks)와 (/api/bookmarks/profile/{userId})
+ * @POST: 북마크 생성                                          : (/api/bookmarks)
+ * @PUT: NULL                                                :
+ * @DELETE: 북마크 삭제                                        : (/api/bookmarks)
+ * = 뉴스정보 조회를 위한 역할과 조회수 업데이트를 위한 역할수행
+ */
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmarks, String> {
-    /* 북마크 정보를 담을 BookmarkRepository, 아래는 관력 역할
-     * GET: 북마크 여부 검증, 해당 user의 북마크 리스트 조회          :(/api/bookmarks)와 (/api/bookmarks/profile/{userId})
-     * POST: 북마크 생성                                          : (/api/bookmarks)
-     * PUT: NULL                                                :
-     * DELETE: 북마크 삭제                                        : (/api/bookmarks)
-     * = 뉴스정보 조회를 위한 역할과 조회수 업데이트를 위한 역할수행
-     */
     Bookmarks findByNewsIdAndUserId(String newsId, String userId);       // 북마크 생성시 예외처리와 검증시에 필요한 조회 쿼리
     List<Bookmarks> findAllByUserId(String userId);                      // user의 북마크 리스트 조회를 위해 필요한 쿼리
     void deleteBookmarkByNewsIdAndUserId(String newsId, String userId); // 북마크 삭제를 위해 필요한 쿼리

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
@@ -20,11 +20,12 @@ public class BookmarkService {
      * @param requestBookmarkDTO
      * @return 저장된 북마크 로그의 id가 리턴
      */
-
     public String createBookmark(RequestBookmarkDTO requestBookmarkDTO){
         // + TODO: 북마크 생성 예외처리(기존에 news, user id가 같은 로그가 존재시 예외처리)
         Bookmarks bookmark = Bookmarks.builder()
-                .requestBookmarkDTO(requestBookmarkDTO)
+                .newsId(requestBookmarkDTO.getNewsId())
+                .userId(requestBookmarkDTO.getUserId())
+                .title(requestBookmarkDTO.getTitle())
                 .build();
         return bookmarkRepository.save(bookmark).getId();
     }

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
@@ -4,6 +4,7 @@ import com.teamharmony.newscommunity.bookmarks.dto.RequestBookmarkDTO;
 import com.teamharmony.newscommunity.bookmarks.dto.ResponseBookmarkDTO;
 import com.teamharmony.newscommunity.bookmarks.entity.Bookmarks;
 import com.teamharmony.newscommunity.bookmarks.repository.BookmarkRepository;
+import com.teamharmony.newscommunity.exception.InvalidRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -49,6 +50,10 @@ public class BookmarkService {
      */
     @Transactional
     public String deleteBookmark(RequestBookmarkDTO requestBookmarkDTO){
+        // + DONE: 북마크가 존재하지 않으면 예외처리
+        if (checkBookmarkDuplicate(requestBookmarkDTO) == null){
+            throw new InvalidRequestException("해당 사용자는 북마크 하지 않았기 때문에 북마크 해제 요청을 할 수 없습니다.", ("newsId: " + requestBookmarkDTO.getNewsId() + ", userId: "+ requestBookmarkDTO.getNewsId()), "B501");
+        }
         // + TODO: 북마크가 존재하지 않으면 예외처리
         bookmarkRepository.deleteBookmarkByNewsIdAndUserId(requestBookmarkDTO.getNewsId(), requestBookmarkDTO.getUserId());
         return requestBookmarkDTO.getNewsId();

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
@@ -14,12 +14,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
-    //1. TODO: 북마크 생성 (req: newsId, userId) use by deatil.html (res: ApiResponse.success("result", newsID))   //DONE
+
+    /**
+     * /api/bookmarks의 경로로 요청된 POST 메서드의 응답을 처리하는 메서드, 북마크 로그를 생성
+     * @param requestBookmarkDTO
+     * @return 저장된 북마크 로그의 id가 리턴
+     */
+
     public String createBookmark(RequestBookmarkDTO requestBookmarkDTO){
-        /*  /api/bookmarks의 경로로 요청된 POST 메서드의 응답을 처리하는 메서드, 북마크 로그를 생성
-            @param: newsId, userId가 담겨있는 requestBookmarkDTO가 담겨있음
-            @return: 저장된 북마크 로그의 id가 리턴
-         */
         // + TODO: 북마크 생성 예외처리(기존에 news, user id가 같은 로그가 존재시 예외처리)
         Bookmarks bookmark = Bookmarks.builder()
                 .requestBookmarkDTO(requestBookmarkDTO)
@@ -27,12 +29,12 @@ public class BookmarkService {
         return bookmarkRepository.save(bookmark).getId();
     }
 
-    //2. TODO: 북마크 여부 검증(req: newsId, userId) use by detail.html (res: ApiResponse.success("result", newsId))      //DONE
+    /**
+     * /api/bookmarks의 경로로 요청된 GET 메서드의 응답을 처리하는 메서드, 북마크 여부 검증을 함
+     * @param requestBookmarkDTO
+     * @return 해당 newsId, userId의 복합키가 북마크 db에 존재하는지 여부 리턴(true||false)
+     */
     public Boolean isBookmarkCheck(RequestBookmarkDTO requestBookmarkDTO){
-        /*  /api/bookmarks의 경로로 요청된 GET 메서드의 응답을 처리하는 메서드, 북마크 여부 검증을 함
-            @param: newsId, userId가 담겨있는 requestBookmarkDTO가 담겨있음
-            @return: 해당 newsId, userId의 복합키가 북마크 db에 존재하는지 여부 리턴(true||false)
-         */
         try {
             bookmarkRepository.findByNewsIdAndUserId(requestBookmarkDTO.getNewsId(), requestBookmarkDTO.getUserId()).getUserId();
             return true;
@@ -42,24 +44,24 @@ public class BookmarkService {
         }
     }
 
-    //3. TODO: 북마크 취소 (req: newId, userId) use by detail.html     (res: ApiResponse.success("result", newsId))
+    /**
+     * /api/bookmarks의 경로로 요청된 DELETE 메서드의 응답을 처리하는 메서드. 북마크 취소의 기능으로, db에 있는 해당 조건의 기록을 삭제
+     * @param requestBookmarkDTO
+     * @return 해당 newsId, userId의 복합키가 북마크 db에 존재하는지 여부 리턴(true||false)
+     */
     @Transactional
     public String deleteBookmark(RequestBookmarkDTO requestBookmarkDTO){
-        /*  /api/bookmarks의 경로로 요청된 DELETE 메서드의 응답을 처리하는 메서드. 북마크 취소의 기능으로, db에 있는 해당 조건의 기록을 삭제
-            @param: newsId, userId가 담겨있는 requestBookmarkDTO가 담겨있음
-            @return: 해당 newsId, userId의 복합키가 북마크 db에 존재하는지 여부 리턴(true||false)
-         */
         // + TODO: 북마크가 존재하지 않으면 예외처리
         bookmarkRepository.deleteBookmarkByNewsIdAndUserId(requestBookmarkDTO.getNewsId(), requestBookmarkDTO.getUserId());
         return requestBookmarkDTO.getNewsId();
     }
 
-    //4. TODO: 북마크 리스트 조회 (req: userId) use by profile.html     (res: ApiResponse.success("result", List<Bookmark>))
+    /**
+     * /api/bookmarks/profiles/{userId}의 경로로 요청된 GET 메서드의 응답을 처리하는 메서드, 해당 userId가 포함된 bookmark리스트 리턴
+     * @param userId
+     * @return 해당 userId가 포함된 bookmark 리스트
+     */
     public ResponseBookmarkDTO selectAllUserBookmark(String userId) {
-        /* /api/bookmarks/profiles/{userId}의 경로로 요청된 GET 메서드의 응답을 처리하는 메서드, 해당 userId가 포함된 bookmark리스트 리턴
-            @param: 클라이언트에서 보낸준 userId
-            @return: 해당 userId가 포함된 bookmark 리스트
-        */
         return ResponseBookmarkDTO.builder()
                 .bookmarksList(bookmarkRepository.findAllByUserId(userId))
                 .build();

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
@@ -36,13 +36,10 @@ public class BookmarkService {
      * @return 해당 newsId, userId의 복합키가 북마크 db에 존재하는지 여부 리턴(true||false)
      */
     public Boolean isBookmarkCheck(RequestBookmarkDTO requestBookmarkDTO){
-        try {
-            bookmarkRepository.findByNewsIdAndUserId(requestBookmarkDTO.getNewsId(), requestBookmarkDTO.getUserId()).getUserId();
-            return true;
-        }catch(NullPointerException n){
-            System.out.println(n.toString());
+        if (checkBookmarkDuplicate(requestBookmarkDTO) == null){
             return false;
         }
+        return true;
     }
 
     /**
@@ -66,5 +63,15 @@ public class BookmarkService {
         return ResponseBookmarkDTO.builder()
                 .bookmarksList(bookmarkRepository.findAllByUserId(userId))
                 .build();
+    }
+
+    /**
+     * 북마크 여부 파악을 위한 메서드
+     * @param requestBookmarkDTO
+     * @return 북마크 존재시 true, 그 외 false
+     */
+    public Bookmarks checkBookmarkDuplicate(RequestBookmarkDTO requestBookmarkDTO){
+        Bookmarks bookmarks = bookmarkRepository.findByNewsIdAndUserId(requestBookmarkDTO.getNewsId(), requestBookmarkDTO.getUserId());
+        return bookmarks;
     }
 }

--- a/src/main/java/com/teamharmony/newscommunity/exception/Error.java
+++ b/src/main/java/com/teamharmony/newscommunity/exception/Error.java
@@ -1,0 +1,11 @@
+package com.teamharmony.newscommunity.exception;
+
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+public class Error {
+    private String field;
+    private String message;
+    private String invalidValue;
+}

--- a/src/main/java/com/teamharmony/newscommunity/exception/ErrorResponse.java
+++ b/src/main/java/com/teamharmony/newscommunity/exception/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.teamharmony.newscommunity.exception;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ErrorResponse {
+    String statusCode;
+    String requestUrl;
+    String code;
+    String message;
+    String resultCode;
+
+    List<Error> errorList;
+}

--- a/src/main/java/com/teamharmony/newscommunity/exception/InvalidRequestException.java
+++ b/src/main/java/com/teamharmony/newscommunity/exception/InvalidRequestException.java
@@ -1,0 +1,22 @@
+package com.teamharmony.newscommunity.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidRequestException extends IllegalArgumentException{
+    private String invalidValue;
+    private String code;
+
+    // 적절치 못한 인자를 넘겨주었을 때 //
+    public InvalidRequestException(String message, String invalidValue, String code) {
+        super(message);
+        this.invalidValue = invalidValue;
+        this.code = code;
+    }
+
+    public InvalidRequestException(String message, Throwable cause, String invalidValue, String code) {
+        super(message, cause);
+        this.invalidValue = invalidValue;
+        this.code = code;
+    }
+}


### PR DESCRIPTION
[Doc]
기존 주석을 javadoc 형식으로 수정

[Refactor]
북마크 생성 로직의 builder 패턴 정확하게 적용

[Feat]
북마크 상태 여부 체크를 위한 로직 구현
예외에 대한 데이터를 닮을 Error 클래스 구현
에러에 대한 응답 형식인 ErrorResponse 클래스 생성
IllegalArgumentException을 상속받는 커스텀 에러 InvalidRequestException 생성
전역적인 예외처리를 위한 예외처리 핸들러 구현
북마크 삭제에 적용

Fixed: #78, #85, #91