### PR TITLE
Fix: 댓글의 content column의 크기를 수정 

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/comments/entity/Comment.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/entity/Comment.java
@@ -25,6 +25,7 @@ public class Comment extends Timestamped {
     @Id
     private Long commentId;
     @Size(max = 300, message = "글자수 초과")
+    @Column(length = 1000)
     private String content;
     private String newsId;
 


### PR DESCRIPTION
- column의 크기를 수정하지 않고 하는 방법이 있는 줄 알았으나 없는 관계로 다시 수정하여 PR 합니다..

Fixed: #93 