### PR TITLE
ResponseEntity로 API 리턴 타입 통일 (뉴스 도메인, 북마크 도메인)

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/controller/BookmarkController.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/controller/BookmarkController.java
@@ -23,19 +23,21 @@ public class BookmarkController {
      * @return 생성된 북마크의 식별번호(Id: String, based on UUID4)
      */
     @PostMapping("")
-    public ApiResponse<String> createBookmark(@RequestBody BookmarkRequestDto requestBookmarkDTO){
-        return ApiResponse.success("result", bookmarkService.createBookmark(requestBookmarkDTO));
+    public ResponseEntity<String> createBookmark(@RequestBody BookmarkRequestDto requestBookmarkDTO){
+        return ResponseEntity.status(HttpStatus.OK).body(bookmarkService.createBookmark(requestBookmarkDTO));
     }
+
 
     /**
      * detail.html에서 해당 뉴스의 id와 읽고 있는 userId를 가지고 사용자가 뉴스를 북마크했는지 판별
-     * @param requestBookmarkDTO
+     * @param newsId
+     * @param userId
      * @return 해당 뉴스에 대한 사용자의 북마크 여부 (True||False)
      */
     @GetMapping("")
-    public ApiResponse<Boolean> isBookmark(@RequestParam String newsId, @RequestParam String userId){
+    public ResponseEntity<Boolean> isBookmark(@RequestParam String newsId, @RequestParam String userId){
         BookmarkRequestDto requestBookmarkDTO = new BookmarkRequestDto(newsId, userId, null);
-        return ApiResponse.success("result", bookmarkService.isBookmarkCheck(requestBookmarkDTO));
+        return ResponseEntity.status(HttpStatus.OK).body(bookmarkService.isBookmarkCheck(requestBookmarkDTO));
     }
 
 
@@ -45,8 +47,8 @@ public class BookmarkController {
      * @return 해당 뉴스에 대한 사용자의 북마크 여부 (True||False)
      */
     @DeleteMapping("")
-    public ApiResponse<String> cancel(@RequestBody BookmarkRequestDto requestBookmarkDTO){
-        return ApiResponse.success("result", bookmarkService.deleteBookmark(requestBookmarkDTO));
+    public ResponseEntity<String> cancel(@RequestBody BookmarkRequestDto requestBookmarkDTO){
+        return ResponseEntity.status(HttpStatus.OK).body(bookmarkService.deleteBookmark(requestBookmarkDTO));
     }
 
     /**

--- a/src/main/java/com/teamharmony/newscommunity/news/controller/NewsController.java
+++ b/src/main/java/com/teamharmony/newscommunity/news/controller/NewsController.java
@@ -1,5 +1,6 @@
 package com.teamharmony.newscommunity.news.controller;
 
+import com.amazonaws.Response;
 import com.teamharmony.newscommunity.common.ApiResponse;
 import com.teamharmony.newscommunity.news.dto.CreateNewsAccessLogRequestDto;
 import com.teamharmony.newscommunity.news.dto.NewsDetailResponseDto;
@@ -36,8 +37,8 @@ public class NewsController {
      * @return      뉴스 상세 정보가 담긴 ResponseNewsDetailDTO
      */
     @GetMapping("/details/{newsId}")
-    public ApiResponse<NewsDetailResponseDto> getNewsDetial(@PathVariable String newsId){
-        return ApiResponse.success("result", newsService.getNewsDetail(newsId));
+    public ResponseEntity<NewsDetailResponseDto> getNewsDetial(@PathVariable String newsId){
+        return ResponseEntity.status(HttpStatus.OK).body(newsService.getNewsDetail(newsId));
     }
 
     /**
@@ -46,9 +47,9 @@ public class NewsController {
      * @See NewsService#setNewsAccessLog
      */
     @PostMapping("/logs")
-    public ApiResponse<String> createNewsAccessLog(@RequestBody CreateNewsAccessLogRequestDto requestCreateNewsAccessLogDTO){
+    public ResponseEntity<String> createNewsAccessLog(@RequestBody CreateNewsAccessLogRequestDto requestCreateNewsAccessLogDTO){
         String newsId = newsService.setNewsAccessLog(requestCreateNewsAccessLogDTO);
-        return ApiResponse.success("result", newsId);
+        return ResponseEntity.status(HttpStatus.OK).body(newsId);
     }
 
     /**
@@ -56,8 +57,8 @@ public class NewsController {
      * @return 조회수 업데이트 성공여부
      */
     @PutMapping("/views/{newsId}")
-    public ApiResponse<String> UpdateView(@PathVariable String newsId){
+    public ResponseEntity<String> UpdateView(@PathVariable String newsId){
         newsService.addView(newsId);
-        return ApiResponse.success("result", "success");
+        return ResponseEntity.status(HttpStatus.OK).body("success");
     }
 }


### PR DESCRIPTION
[Refactor]
- Refactor: 뉴스 도메인의 Response 형식 ApiResponse-> ResponseEntity로 변경

- Refactor: 뉴스 도메인의 Response 형식 ApiResponse-> ResponseEntity로 변경

FIxed: #45--