### PR TITLE
Comment Entity column 크기 @Size 와 @Column(length = ) 중복 삭제

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/comments/entity/Comment.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/entity/Comment.java
@@ -25,7 +25,6 @@ public class Comment extends Timestamped {
     @Id
     private Long commentId;
     @Size(max = 300, message = "글자수 초과")
-    @Column(length = 1000)
     private String content;
     private String newsId;
 


### PR DESCRIPTION
## 🎵 설명
: Comment Entity에 content 칼럼의 크기를 @Size와 @Column으로 중복으로 설정을 해놔서 @Column을 삭제했습니다.
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: 없습니당.
<br>

## 🏷 해결한 이슈 번호 
Fixed: #124 
<br>

## 📌 Merge 제목
`Merge: develop <- `브랜치명 #pr번호
