### PR TITLE
뉴스, 북마크 도메인에 대한 예외처리 적용 및 에러 객체 생성 방식 변경

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
@@ -24,7 +24,10 @@ public class BookmarkService {
      * @return 저장된 북마크 로그의 id가 리턴
      */
     public String createBookmark(BookmarkRequestDto requestBookmarkDTO){
-        // + TODO: 북마크 생성 예외처리(기존에 news, user id가 같은 로그가 존재시 예외처리)
+        if (checkBookmarkDuplicate(requestBookmarkDTO) != null){
+            throw new InvalidRequestException("해당 사용자는 이미 해당 뉴스에 북마크 되어있기 때문에 북마크 요청을 할 수 없습니다.", ("newsId: " + requestBookmarkDTO.getNewsId() + ", userId: "+ requestBookmarkDTO.getNewsId()), "B402");
+        }
+
         Bookmarks bookmark = Bookmarks.builder()
                 .newsId(requestBookmarkDTO.getNewsId())
                 .userId(requestBookmarkDTO.getUserId())
@@ -54,7 +57,7 @@ public class BookmarkService {
     public String deleteBookmark(BookmarkRequestDto requestBookmarkDTO){
         // + DONE: 북마크가 존재하지 않으면 예외처리
         if (checkBookmarkDuplicate(requestBookmarkDTO) == null){
-            throw new InvalidRequestException("해당 사용자는 북마크 하지 않았기 때문에 북마크 해제 요청을 할 수 없습니다.", ("newsId: " + requestBookmarkDTO.getNewsId() + ", userId: "+ requestBookmarkDTO.getNewsId()), "B501");
+            throw new InvalidRequestException("해당 사용자는 북마크 하지 않았기 때문에 북마크 해제 요청을 할 수 없습니다.", ("newsId: " + requestBookmarkDTO.getNewsId() + ", userId: "+ requestBookmarkDTO.getNewsId()), "B401");
         }
         // + TODO: 북마크가 존재하지 않으면 예외처리
         bookmarkRepository.deleteBookmarkByNewsIdAndUserId(requestBookmarkDTO.getNewsId(), requestBookmarkDTO.getUserId());

--- a/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
+++ b/src/main/java/com/teamharmony/newscommunity/bookmarks/service/BookmarkService.java
@@ -25,7 +25,11 @@ public class BookmarkService {
      */
     public String createBookmark(BookmarkRequestDto requestBookmarkDTO){
         if (checkBookmarkDuplicate(requestBookmarkDTO) != null){
-            throw new InvalidRequestException("해당 사용자는 이미 해당 뉴스에 북마크 되어있기 때문에 북마크 요청을 할 수 없습니다.", ("newsId: " + requestBookmarkDTO.getNewsId() + ", userId: "+ requestBookmarkDTO.getNewsId()), "B402");
+            throw InvalidRequestException.builder()
+                    .message("해당 사용자는 이미 해당 뉴스에 북마크 되어있기 때문에 북마크 요청을 할 수 없습니다.")
+                    .invalidValue(("newsId: " + requestBookmarkDTO.getNewsId() + ", userId: "+ requestBookmarkDTO.getNewsId()))
+                    .code("B402")
+                    .build();
         }
 
         Bookmarks bookmark = Bookmarks.builder()
@@ -57,7 +61,11 @@ public class BookmarkService {
     public String deleteBookmark(BookmarkRequestDto requestBookmarkDTO){
         // + DONE: 북마크가 존재하지 않으면 예외처리
         if (checkBookmarkDuplicate(requestBookmarkDTO) == null){
-            throw new InvalidRequestException("해당 사용자는 북마크 하지 않았기 때문에 북마크 해제 요청을 할 수 없습니다.", ("newsId: " + requestBookmarkDTO.getNewsId() + ", userId: "+ requestBookmarkDTO.getNewsId()), "B401");
+            throw InvalidRequestException.builder()
+                    .message("해당 사용자는 북마크 하지 않았기 때문에 북마크 해제 요청을 할 수 없습니다.")
+                    .invalidValue(("newsId: " + requestBookmarkDTO.getNewsId() + ", userId: "+ requestBookmarkDTO.getNewsId()))
+                    .code("B401")
+                    .build();
         }
         // + TODO: 북마크가 존재하지 않으면 예외처리
         bookmarkRepository.deleteBookmarkByNewsIdAndUserId(requestBookmarkDTO.getNewsId(), requestBookmarkDTO.getUserId());

--- a/src/main/java/com/teamharmony/newscommunity/exception/InvalidRequestException.java
+++ b/src/main/java/com/teamharmony/newscommunity/exception/InvalidRequestException.java
@@ -1,5 +1,6 @@
 package com.teamharmony.newscommunity.exception;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -8,14 +9,9 @@ public class InvalidRequestException extends IllegalArgumentException{
     private String code;
 
     // 적절치 못한 인자를 넘겨주었을 때 //
-    public InvalidRequestException(String message, String invalidValue, String code) {
+    @Builder
+    public InvalidRequestException(String message,  String invalidValue, String code){
         super(message);
-        this.invalidValue = invalidValue;
-        this.code = code;
-    }
-
-    public InvalidRequestException(String message, Throwable cause, String invalidValue, String code) {
-        super(message, cause);
         this.invalidValue = invalidValue;
         this.code = code;
     }

--- a/src/main/java/com/teamharmony/newscommunity/news/service/NewsService.java
+++ b/src/main/java/com/teamharmony/newscommunity/news/service/NewsService.java
@@ -1,5 +1,6 @@
 package com.teamharmony.newscommunity.news.service;
 
+import com.teamharmony.newscommunity.exception.InvalidRequestException;
 import com.teamharmony.newscommunity.news.dto.CreateNewsAccessLogRequestDto;
 import com.teamharmony.newscommunity.news.dto.NewsDetailResponseDto;
 import com.teamharmony.newscommunity.news.entity.NewsAccessLog;
@@ -39,9 +40,8 @@ public class NewsService {
      * @Return: ResponseNewsDetailDTO // newsid, title, summary, image_url, news_url, write_time, view 가 담김
      **/
     public NewsDetailResponseDto getNewsDetail(String newsId){
-
         NewsTable newsTable = newsRepository.findById(newsId).orElseThrow(
-                ()-> new NullPointerException("해당 뉴스 id가 존재 안합니다.")
+                ()-> new InvalidRequestException("존재하지 않는 newsId에 대해 요청했습니다.", "newsId: "+ newsId, "N401")
         );
         return NewsDetailResponseDto.builder()
                 .id(newsTable.getId())
@@ -73,7 +73,7 @@ public class NewsService {
     @Transactional
     public void addView(String newsId) {
         NewsTable newsTable = newsRepository.findById(newsId).orElseThrow(
-                ()-> new NullPointerException("해당 뉴스가 존재 안합니다.")
+                ()-> new InvalidRequestException("존재하지 않는 newsId에 대해 요청했습니다.", "newsId: "+ newsId, "N402")
         );
         newsTable.updateView();
         newsRepository.save(newsTable);

--- a/src/main/java/com/teamharmony/newscommunity/news/service/NewsService.java
+++ b/src/main/java/com/teamharmony/newscommunity/news/service/NewsService.java
@@ -41,7 +41,11 @@ public class NewsService {
      **/
     public NewsDetailResponseDto getNewsDetail(String newsId){
         NewsTable newsTable = newsRepository.findById(newsId).orElseThrow(
-                ()-> new InvalidRequestException("존재하지 않는 newsId에 대해 요청했습니다.", "newsId: "+ newsId, "N401")
+                ()-> InvalidRequestException.builder()
+                        .message("존재하지 않는 newsId에 대해 요청했습니다.")
+                        .invalidValue("newsId: "+ newsId)
+                        .code("N401")
+                        .build()
         );
         return NewsDetailResponseDto.builder()
                 .id(newsTable.getId())
@@ -73,7 +77,11 @@ public class NewsService {
     @Transactional
     public void addView(String newsId) {
         NewsTable newsTable = newsRepository.findById(newsId).orElseThrow(
-                ()-> new InvalidRequestException("존재하지 않는 newsId에 대해 요청했습니다.", "newsId: "+ newsId, "N402")
+                ()-> InvalidRequestException.builder()
+                                        .message("존재하지 않는 newsId에 대해 요청했습니다.")
+                                        .invalidValue("newsId: "+ newsId)
+                                        .code("N402")
+                                        .build()
         );
         newsTable.updateView();
         newsRepository.save(newsTable);


### PR DESCRIPTION
## 🎵 설명
: 뉴스, 북마크 도메인에 대한 예외처리 적용 및 에러 객체 생성 방식 변경
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: 기존 InvalidRequestException 객체 생성시에 생성자로 생성하던 부분을 모두 Builder 패턴으로 변경 필요
<br>

## 🏷 해결한 이슈 번호 
Fixed: #132
<br>

## 📌 Merge 제목
Merge: develop <- 132/feat_exception-bookmark-news #133
