### PR TITLE
모든 GET요청을 허용하고 비로그인 이용자 열람 및 기록을 위한 어노테이션 변경

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/aop/ParameterAop.java
+++ b/src/main/java/com/teamharmony/newscommunity/aop/ParameterAop.java
@@ -26,7 +26,7 @@ public class ParameterAop {
         System.out.println(method.getName());
         Object[] args = joinPoint.getArgs();
         for(Object obj : args){
-            log.info("input parameter: {}", obj.getClass().getSimpleName());
+            log.info("input parameter: {}", obj!=null ? obj.getClass().getSimpleName() : null);
             log.info("request: {}", obj);
         }
     }

--- a/src/main/java/com/teamharmony/newscommunity/auth/config/security/SecurityConfig.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/config/security/SecurityConfig.java
@@ -36,18 +36,17 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	protected void configure(HttpSecurity http) throws Exception {
 		CustomAuthenticationFilter customAuthenticationFilter = new CustomAuthenticationFilter(authenticationManagerBean(), userDetailsService, tokensRepository);
 		customAuthenticationFilter.setFilterProcessesUrl("/api/login");
-		http.csrf()
-		    .ignoringAntMatchers("/h2-console/**")
-		    .disable();
+		http.csrf().disable();
 		http.formLogin().disable();
 		http.httpBasic().disable();
 		http.sessionManagement().sessionCreationPolicy(STATELESS);
-		http.authorizeRequests().antMatchers("/h2-console/**").permitAll();
 		
-		http.authorizeRequests().antMatchers("/api/login/**", "/api/token/**", "/api/signup/**", "/api/news/**", "/api/bookmarks/**", "/api/supports/**").permitAll();
-		http.authorizeRequests().antMatchers(GET, "/api/user/**").hasAuthority("ROLE_USER");
-		http.authorizeRequests().antMatchers(GET, "/api/admin/**").hasAuthority("ROLE_ADMIN");
-		http.authorizeRequests().anyRequest().authenticated();
+		http.authorizeRequests()
+		    .antMatchers("/api/login/**", "/api/signup", "/api/news/**", "/api/bookmarks/**").permitAll()
+		    .antMatchers(GET, "/api/**").permitAll()
+		    .antMatchers("/api/user/**").hasAuthority("ROLE_USER")
+				.antMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
+				.anyRequest().authenticated();
 		
 		http.addFilter(customAuthenticationFilter);
 		// this filter comes before the other filters

--- a/src/main/java/com/teamharmony/newscommunity/auth/controller/AuthController.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.teamharmony.newscommunity.auth.controller;
 
 import com.teamharmony.newscommunity.auth.service.AuthService;
+import com.teamharmony.newscommunity.common.annotation.CurrentUser;
 import com.teamharmony.newscommunity.exception.TokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -37,11 +38,11 @@ public class AuthController {
 	/**
 	 * 로그아웃
 	 *
-	 * @param 		user 인증된 사용자 정보
+	 * @param 		username 인증된 사용자 ID
 	 * @see				AuthService#signOut
 	 */
 	@GetMapping("/user/signout")
-	public ResponseEntity<String> signOut(HttpServletRequest request, HttpServletResponse response, @AuthenticationPrincipal UserDetails user) throws TokenException {
-		return ResponseEntity.ok().body(authService.signOut(request, response, user.getUsername()));
+	public ResponseEntity<String> signOut(HttpServletRequest request, HttpServletResponse response, @CurrentUser String username) throws TokenException {
+		return ResponseEntity.ok().body(authService.signOut(request, response, username));
 	}
 }

--- a/src/main/java/com/teamharmony/newscommunity/auth/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/teamharmony/newscommunity/auth/filter/CustomAuthorizationFilter.java
@@ -39,11 +39,9 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 	
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+		// get 아니고 누군지 분간할 필요도 없는 거
 		if (request.getServletPath().equals("/api/login") ||
-				request.getServletPath().equals("/api/token/refresh") ||
-				request.getServletPath().startsWith("/api/signup") ||
-				request.getServletPath().startsWith("/api/supports") ||
-				request.getServletPath().startsWith("/api/news")) {
+				request.getServletPath().startsWith("/api/signup")) {
 			
 			filterChain.doFilter(request, response);
 		} else {

--- a/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.teamharmony.newscommunity.comments.dto.CommentCreateRequestDto;
 import com.teamharmony.newscommunity.comments.dto.CommentEditRequestDto;
 import com.teamharmony.newscommunity.comments.dto.CommentResponseDto;
 import com.teamharmony.newscommunity.comments.service.CommentService;
+import com.teamharmony.newscommunity.common.annotation.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,13 +24,12 @@ public class CommentController {
     /**
      * requestBody로 넘어오는 댓글내용과 newsId를 받아서 저장합니다.
      * @param commentCreateRequestDto
-     * @param user
+     * @param username
      * @return 저장된 댓글의 id
      */
     @PostMapping("/user/comments")
     public ResponseEntity<?> saveComment(@RequestBody @Valid CommentCreateRequestDto commentCreateRequestDto,
-                                         @AuthenticationPrincipal UserDetails user) {
-        String username = user.getUsername();
+                                         @CurrentUser String username) {
         commentService.createComment(commentCreateRequestDto, username);
         return ResponseEntity.ok().body("댓글 작성 성공");
     }

--- a/src/main/java/com/teamharmony/newscommunity/comments/controller/LikesController.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/controller/LikesController.java
@@ -1,6 +1,7 @@
 package com.teamharmony.newscommunity.comments.controller;
 
 import com.teamharmony.newscommunity.comments.service.LikesService;
+import com.teamharmony.newscommunity.common.annotation.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,12 +19,11 @@ public class LikesController {
     /**
      * 좋아요 요청을 받는 API
      * @param id
-     * @param user
+     * @param username
      */
     @PostMapping("/user/likes/{id}")
     public ResponseEntity<?> likes(@PathVariable Long id,
-                                   @AuthenticationPrincipal UserDetails user) {
-        String username = user.getUsername();
+                                   @CurrentUser String username) {
         likesService.likes(id, username);
         return ResponseEntity.ok().body("좋아요");
     }

--- a/src/main/java/com/teamharmony/newscommunity/common/annotation/CurrentUser.java
+++ b/src/main/java/com/teamharmony/newscommunity/common/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.teamharmony.newscommunity.common.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : username")
+public @interface CurrentUser {
+}

--- a/src/main/java/com/teamharmony/newscommunity/supports/controller/SupportController.java
+++ b/src/main/java/com/teamharmony/newscommunity/supports/controller/SupportController.java
@@ -1,6 +1,7 @@
 package com.teamharmony.newscommunity.supports.controller;
 
 import com.teamharmony.newscommunity.comments.dto.CommentResponseDto;
+import com.teamharmony.newscommunity.common.annotation.CurrentUser;
 import com.teamharmony.newscommunity.supports.dto.SupportRequestDto;
 import com.teamharmony.newscommunity.supports.dto.SupportRequestUpdateDto;
 import com.teamharmony.newscommunity.supports.dto.SupportResponseDto;
@@ -25,13 +26,12 @@ public class SupportController {
     /**
      * 게시글 생성 : requestBody로 넘어오는 게시글 제목과 내용, 작성자의 Email주소를 받아서 저장. Email주소는 유효성을 검사.
      * @param requestDto
-     * @param user
+     * @param username
      * @return support 객체
      * @see SupportService#generateSupport
      */
     @PostMapping("/user/supports")
-    public Support createSupport(@RequestBody @Valid SupportRequestDto requestDto, @AuthenticationPrincipal UserDetails user) {
-        String username = user.getUsername();
+    public Support createSupport(@RequestBody @Valid SupportRequestDto requestDto, @CurrentUser String username) {
         return supportService.generateSupport(requestDto, username);
     }
 
@@ -48,13 +48,12 @@ public class SupportController {
 
     /**
      * 유저별 Support 게시글 조회 : 각 유저가 생성한 게시글만 불러옴
-     * @param user
+     * @param username
      * @return support 객체
      * @see SupportService#getMySupportList
      */
     @GetMapping("/user/supports/mine")
-    public ResponseEntity<List<SupportResponseDto>> getMySupportList(@AuthenticationPrincipal UserDetails user) {
-        String username = user.getUsername();
+    public ResponseEntity<List<SupportResponseDto>> getMySupportList(@CurrentUser String username) {
         List<SupportResponseDto> supportList = supportService.getMySupportList(username);
         return ResponseEntity.ok().body(supportList);
     }
@@ -62,26 +61,25 @@ public class SupportController {
      * 게시글 수정 : requestBody인 supportRequestUpdateDto로 넘어오는 게시글 내용으로 content_id에 해당하는 게시글 업데이트
      * @param content_id
      * @param supportRequestUpdateDto
-     * @param user
+     * @param username
      * @return 수정된 댓글의 contentId
      * @see SupportService#updateSuppport
      */
     @PutMapping("/user/supports/{content_id}")
-    public ResponseEntity<Long> modifySupportContent(@PathVariable Long content_id, @RequestBody SupportRequestUpdateDto supportRequestUpdateDto, @AuthenticationPrincipal UserDetails user) {
-        String username = user.getUsername();
+    public ResponseEntity<Long> modifySupportContent(@PathVariable Long content_id, @RequestBody SupportRequestUpdateDto supportRequestUpdateDto, @CurrentUser String username) {
         Long modifyContentId = supportService.updateSuppport(content_id, supportRequestUpdateDto, username);
         return ResponseEntity.ok().body(modifyContentId);
     }
     /**
      * 게시글 삭제 : content_id에 해당하는 게시글 삭제
      * @param content_id
-     * @param user
+     * @param username
      * @return 삭제된 댓글의 content_id
      * @see SupportService#removeContent
      */
     @DeleteMapping("/user/supports/{content_id}")
-    public ResponseEntity<Long> deleteSupport(@PathVariable Long content_id, @AuthenticationPrincipal UserDetails user) {
-        Long deleteContentId = supportService.removeContent(content_id, user);
+    public ResponseEntity<Long> deleteSupport(@PathVariable Long content_id, @CurrentUser String username) {
+        Long deleteContentId = supportService.removeContent(content_id, username);
         return ResponseEntity.ok().body(deleteContentId);
     }
 }

--- a/src/main/java/com/teamharmony/newscommunity/supports/service/SupportService.java
+++ b/src/main/java/com/teamharmony/newscommunity/supports/service/SupportService.java
@@ -82,15 +82,14 @@ public class SupportService {
     /**
      * 게시글 삭제: parameter로 주어지는 contentId를 찾아서 삭제
      * @param contentId 삭제하려는 support객체의 contentId
-     * @param user 유저정보
+     * @param username 로그인한 사람 이름(unigue)
      * @return contentId 제하려는 support객체의 contentId
      */
-    public Long removeContent(Long contentId, UserDetails user) {
+    public Long removeContent(Long contentId, String username) {
         Support supportObject = supportRepository.findById(contentId).orElseThrow(
                 () -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다.")
         );
         Long supportsUserID = supportObject.getUser().getId(); //현재 게시글에서 userID정보획득
-        String username = user.getUsername(); //현재 로그인한 사람 이름가져오기
         User currentUser = userRepository.findByUsername(username); // 현재 로그인한 사람 이름(unigue)으로 user정보 획득
         Long loginUserId = currentUser.getId();// 로그인한 사용자ID 정보(Long) 획득
 

--- a/src/main/java/com/teamharmony/newscommunity/users/controller/UserController.java
+++ b/src/main/java/com/teamharmony/newscommunity/users/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.teamharmony.newscommunity.users.controller;
 
+import com.teamharmony.newscommunity.common.annotation.CurrentUser;
 import com.teamharmony.newscommunity.users.dto.UserResponseDto;
 import com.teamharmony.newscommunity.users.service.UserService;
 import com.teamharmony.newscommunity.users.vo.ProfileVO;
@@ -77,13 +78,12 @@ public class UserController {
 	/**
 	 * 현재 로그인한 유저 ID
 	 *
-	 * @param 		user 인증된 사용자 정보
+	 * @param 		username 인증된 사용자 정보
 	 * @return 		인증된 사용자 ID
 	 * @see				UserDetails#getUsername
 	 */
 	@GetMapping("/user/me")
-	public ResponseEntity<String>getUsername(@AuthenticationPrincipal UserDetails user) {
-		String username = user.getUsername();
+	public ResponseEntity<String>getUsername(@CurrentUser String username) {
 		return ResponseEntity.ok().body(username);
 	}
 	
@@ -116,14 +116,14 @@ public class UserController {
 	/**
 	 * 회원 프로필 정보
 	 *
-	 * @param 		username 프로필 회원 ID
-	 * @param 		user 인증된 사용자 정보
+	 * @param 		profileOwner 프로필 회원 ID
+	 * @param 		username 인증된 사용자 정보
 	 * @return 		인증된 사용자 ID와 일치 여부, 프로필 사진 url, 프로필 정보
 	 * @see				UserService#getProfile
 	 */
-	@GetMapping("/user/profile/{username}")
-	public ResponseEntity<Map<String, Object>>getProfile(@PathVariable String username, @AuthenticationPrincipal UserDetails user) {
-		boolean status = username.equals(user.getUsername());
+	@GetMapping("/user/profile/{profileOwner}")
+	public ResponseEntity<Map<String, Object>>getProfile(@PathVariable String profileOwner, @CurrentUser String username) {
+		boolean status = profileOwner.equals(username);
 		URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentContextPath().path("/api/user/profile/{username}").toUriString());
 		return ResponseEntity.created(uri).body(userService.getProfile(username, status));
 	}
@@ -145,7 +145,7 @@ public class UserController {
 	 * 회원 프로필 업데이트
 	 *
 	 * @param 		profile 닉네임, 프로필 사진 파일, 소개글을 담은 객체
-	 * @param 		user 인증된 사용자 정보
+	 * @param 		username 인증된 사용자 정보
 	 * @return 		성공 확인, 메시지
 	 * @see				UserService#updateProfile
 	 */
@@ -154,8 +154,7 @@ public class UserController {
 			consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
 			produces = MediaType.APPLICATION_JSON_VALUE
 	)
-	public ResponseEntity<?>updateProfile(ProfileVO profile, @AuthenticationPrincipal UserDetails user) {
-		String username = user.getUsername();
+	public ResponseEntity<?>updateProfile(ProfileVO profile, @CurrentUser String username) {
 		URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentContextPath().path("/api/user/update_profile").toUriString());
 		return ResponseEntity.created(uri).body(userService.updateProfile(username, profile));
 	}


### PR DESCRIPTION
## 🎵 설명
: 모든 GET 요청을 열었습니다.
GET 이외의 요청은 user 포함된 url의 경우 권한이 필요하도록 했고
기존 인가 통과되던 요청들은 비로그인 사용자의 경우도 예외가 발생하지 않기 때문에 통과하지 않도록 수정했습니다.
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: comment와 support 패키지는 변동이 많으니 주의하세요!!!@@@ @YoungeunJo  @hyunzxn https://github.com/2022-Harmony/NewsCommunity-bFinal/pull/158/commits/34d4264729e62a3f3f1061788bdb55695807e3bc
<br>

## 🏷 해결한 이슈 번호 
Fixed: #156 #157
<br>

## 📌 Merge 제목
`Merge: develop <- `157/fix_authorization #pr번호
