### PR TITLE
비로그인 상태에서 프로필 조회 불가한 오류

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/users/controller/UserController.java
+++ b/src/main/java/com/teamharmony/newscommunity/users/controller/UserController.java
@@ -125,7 +125,7 @@ public class UserController {
 	public ResponseEntity<Map<String, Object>>getProfile(@PathVariable String profileOwner, @CurrentUser String username) {
 		boolean status = profileOwner.equals(username);
 		URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentContextPath().path("/api/user/profile/{username}").toUriString());
-		return ResponseEntity.created(uri).body(userService.getProfile(username, status));
+		return ResponseEntity.created(uri).body(userService.getProfile(profileOwner, status));
 	}
 	
 	/**


### PR DESCRIPTION
## 🎵 설명
:  변수명을 수정하면서 로그인한 사용자 ID를 넘겨줘 조회 불가 오류가 발생했습니다.
프로필 주인의 ID가 전달되도록 수정했습니다!
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: 앞에 pr 머지할 때 발견 못했습니다...죄송합니다. 하지만 제 pr을 아무도 봐주시지 않았어요!!!!@@@@
<br>

## 🏷 해결한 이슈 번호 
Fixed: #160
<br>

## 📌 Merge 제목
`Merge: develop <- `160/bug_get-profile #pr번호
