### PR TITLE
좋아요 이력을 포함한 CommentResponseDto 반환

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/dto/CommentResponseDto.java
@@ -14,6 +14,7 @@ public class CommentResponseDto {
     private LocalDateTime createdAt;
     private String content;
     private ProfileResponseDto profileResponseDto;
+    private Boolean like;
 
 
 
@@ -22,13 +23,15 @@ public class CommentResponseDto {
                               LocalDateTime modifiedAt,
                               LocalDateTime createdAt,
                               String content,
-                              ProfileResponseDto profileResponseDto) {
+                              ProfileResponseDto profileResponseDto,
+                              Boolean like) {
 
         this.commentId = commentId;
         this.modifiedAt = modifiedAt;
         this.createdAt = createdAt;
         this.content = content;
         this.profileResponseDto = profileResponseDto;
+        this.like = like;
     }
 
 }

--- a/src/main/java/com/teamharmony/newscommunity/comments/service/CommentService.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/service/CommentService.java
@@ -4,7 +4,9 @@ import com.teamharmony.newscommunity.comments.dto.CommentCreateRequestDto;
 import com.teamharmony.newscommunity.comments.dto.CommentEditRequestDto;
 import com.teamharmony.newscommunity.comments.dto.CommentResponseDto;
 import com.teamharmony.newscommunity.comments.entity.Comment;
+import com.teamharmony.newscommunity.comments.entity.Likes;
 import com.teamharmony.newscommunity.comments.repository.CommentRepository;
+import com.teamharmony.newscommunity.comments.repository.LikesRepository;
 import com.teamharmony.newscommunity.exception.InvalidRequestException;
 import com.teamharmony.newscommunity.users.dto.ProfileResponseDto;
 import com.teamharmony.newscommunity.users.entity.User;
@@ -25,6 +27,7 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
+    private final LikesRepository likesRepository;
 
     @Transactional
     public void createComment(CommentCreateRequestDto commentCreateRequestDto, String username) {
@@ -45,6 +48,8 @@ public class CommentService {
     public List<CommentResponseDto> findComments(String newsId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Comment> commentList = commentRepository.findAllByNewsId(newsId, pageable);
+
+
         if (commentList == null) {
             throw new InvalidRequestException("댓글을 불러올 수 없습니다", "뉴스 아이디가 댓글에 잘 저장됐는지 확인하세요", "C402");
         }
@@ -54,8 +59,14 @@ public class CommentService {
                         .modifiedAt(comment.getModifiedAt())
                         .createdAt(comment.getCreatedAt())
                         .profileResponseDto(new ProfileResponseDto(comment.getUser().getProfile()))
+                        .like(likeCheck(comment.getCommentId(), comment.getUser().getId()))
                         .build())
                         .collect(Collectors.toList());
+    }
+
+    private Boolean likeCheck(Long commentId, Long userId) {
+        Likes likes = likesRepository.findByComment_CommentIdAndUser_Id(commentId, userId);
+        return likes == null ? false : true;
     }
 
     public int getCommentCount(String newsId) {
@@ -110,6 +121,7 @@ public class CommentService {
                         .modifiedAt(comment.getModifiedAt())
                         .createdAt(comment.getCreatedAt())
                         .profileResponseDto(new ProfileResponseDto(comment.getUser().getProfile()))
+                        .like(likeCheck(comment.getCommentId(), comment.getUser().getId()))
                         .build())
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 🎵 설명
- CommentResponseDto에 like 필드를 추가했습니다.
- CommentService에서 CommentResponseDto를 반환할 때 builder 패턴에 like 필드를 추가했습니다.
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
:
<br>

## 🏷 해결한 이슈 번호 
Fixed: #165 
<br>

## 📌 Merge 제목
`Merge: develop <- `브랜치명 #pr번호
