### PR TITLE
s3 업로드시 public 권한으로 객체 생성

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/users/filesotre/FileStore.java
+++ b/src/main/java/com/teamharmony/newscommunity/users/filesotre/FileStore.java
@@ -3,7 +3,9 @@ package com.teamharmony.newscommunity.users.filesotre;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.util.IOUtils;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +27,7 @@ public class FileStore {
 			map.forEach(metadata::addUserMetadata);
 		} });
 		try {
-			s3.putObject(path, fileName, inputStream, metadata);
+			s3.putObject(new PutObjectRequest(path, fileName, inputStream, metadata).withCannedAcl(CannedAccessControlList.PublicRead));
 		} catch (AmazonServiceException e) {
 			throw new IllegalStateException("Failed to store file to s3", e);
 		}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,8 +24,9 @@ spring.servlet.multipart.max-file-size=50MB
 spring.servlet.multipart.max-request-size=50MB
 spring.servlet.multipart.enabled=true
 
-aws.credentials.access-key=accessKey
-aws.credentials.secret-key=secretKey
-aws.s3.bucket-name=bucketName
+aws.credentials.access-key=AKIAVS4GXH2IEUPV6BKG
+aws.credentials.secret-key=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
+aws.s3.bucket-name=harmony-profile
 
 auth.jwt.secret-key=secretKey
+


### PR DESCRIPTION
## 🎵 설명
: s3 업로드시 public 권한으로 객체 생성이 되어야 사용자들이 해당 s3에 접근할 수 있음
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: 프로필 사진 정보가 움직이는 일련의 과정. 사용자에겐 해당 s3의 주소가 리턴되는데, 사용자는 이를 통해 프로필 사진 정보에 접근
<br>

## 🏷 해결한 이슈 번호 
Fixed: #174 
<br>

## 📌 Merge 제목
Merge: develop <- `174/Fix_s3-upload-fix #175 
