### PR TITLE
상세페이지 댓글 페이징과 정렬 개선

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/controller/CommentController.java
@@ -6,6 +6,7 @@ import com.teamharmony.newscommunity.comments.dto.CommentResponseDto;
 import com.teamharmony.newscommunity.comments.service.CommentService;
 import com.teamharmony.newscommunity.common.annotation.CurrentUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -40,11 +41,13 @@ public class CommentController {
      * @return 해당 뉴스 아이디에 해당하는 댓글 리스트
      */
     @GetMapping("/comments/{news_id}/{currentUser}")
-    public ResponseEntity<List<CommentResponseDto>> getComment(@PathVariable String news_id,
-                                                               @RequestParam("page") int page,
-                                                               @RequestParam("size") int size,
-                                                               @PathVariable String currentUser) {
-        return ResponseEntity.ok().body(commentService.findComments(news_id, (page-1), size, currentUser));
+    public ResponseEntity<Page<CommentResponseDto>> getComment(@PathVariable String news_id,
+                                                @RequestParam("page") int page,
+                                                @RequestParam("size") int size,
+                                                @RequestParam("sortBy") String sortBy,
+                                                @RequestParam("isAsc") boolean isAsc,
+                                                @PathVariable String currentUser) {
+        return ResponseEntity.ok().body(commentService.findComments(news_id, (page-1), size, sortBy, isAsc, currentUser));
     }
 
 

--- a/src/main/java/com/teamharmony/newscommunity/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/teamharmony/newscommunity/comments/dto/CommentResponseDto.java
@@ -1,6 +1,10 @@
 package com.teamharmony.newscommunity.comments.dto;
 
+import com.teamharmony.newscommunity.comments.entity.Comment;
 import com.teamharmony.newscommunity.users.dto.ProfileResponseDto;
+import com.teamharmony.newscommunity.users.dto.UserResponseDto;
+import com.teamharmony.newscommunity.users.entity.User;
+import com.teamharmony.newscommunity.users.entity.UserProfile;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -34,4 +38,17 @@ public class CommentResponseDto {
         this.like = like;
     }
 
+    public static CommentResponseDto toDto(Comment comment) {
+        return CommentResponseDto.builder()
+                .commentId(comment.getCommentId())
+                .modifiedAt(comment.getModifiedAt())
+                .createdAt(comment.getCreatedAt())
+                .content(comment.getContent())
+                .profileResponseDto(new ProfileResponseDto(comment.getUser().getProfile()))
+                .build();
+    }
+
+    public void likeUser(Boolean like) {
+        this.like = like;
+    }
 }


### PR DESCRIPTION
## 🎵 설명
- 상세페이지에서 댓글 페이징을 할 때 댓글이 없음에도 페이지 번호가 있어서 계속 넘어가는 부분 수정
- 정렬 기능 사용시 하트 아이콘이 깨지고 페이징한 것이 없어지는 부분 수정
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
:
<br>

## 🏷 해결한 이슈 번호 
Fixed: #188  
<br>

## 📌 Merge 제목
`Merge: develop <- `브랜치명 #pr번호
