### PR TITLE
UserService에서 Profile image 관련 함수를 util로 분리

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/domain/users/service/UserService.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/users/service/UserService.java
@@ -9,6 +9,7 @@ import com.teamharmony.newscommunity.domain.users.repository.RoleRepository;
 import com.teamharmony.newscommunity.domain.users.repository.UserProfileRepository;
 import com.teamharmony.newscommunity.domain.users.repository.UserRepository;
 import com.teamharmony.newscommunity.domain.users.repository.UserRoleRepository;
+import static com.teamharmony.newscommunity.domain.users.util.ProfileUtil.*;
 import com.teamharmony.newscommunity.exception.InvalidRequestException;
 import com.teamharmony.newscommunity.domain.users.filesotre.FileStore;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/teamharmony/newscommunity/domain/users/service/UserService.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/users/service/UserService.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.*;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.http.entity.ContentType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -179,19 +178,6 @@ public class UserService implements UserDetailsService {
 		} else {
 			return "default";
 		}
-	}
-	
-	private Map<String, String> extractMetadata(MultipartFile file) {
-		Map<String, String> metadata = new HashMap<>();
-		metadata.put("Content-Type", file.getContentType());
-		metadata.put("Content-Length", String.valueOf(file.getSize()));
-		return metadata;
-	}
-	
-	private void isImage(MultipartFile file) {
-		if (!Arrays.asList(IMAGE_JPEG.getMimeType(), IMAGE_PNG.getMimeType(), IMAGE_GIF.getMimeType())
-		           .contains(file.getContentType()))
-			throw new InvalidRequestException("파일이 이미지가 아닙니다.", "파일 유형: "+file.getContentType(), "U402");
 	}
 	
 	/**

--- a/src/main/java/com/teamharmony/newscommunity/domain/users/util/ProfileUtil.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/users/util/ProfileUtil.java
@@ -1,0 +1,29 @@
+package com.teamharmony.newscommunity.domain.users.util;
+
+import com.teamharmony.newscommunity.exception.InvalidRequestException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.http.entity.ContentType.*;
+
+public class ProfileUtil {
+    public static Map<String, String> extractMetadata(MultipartFile file) {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("Content-Type", file.getContentType());
+        metadata.put("Content-Length", String.valueOf(file.getSize()));
+        return metadata;
+    }
+
+    public static void isImage(MultipartFile file) {
+        if (!Arrays.asList(IMAGE_JPEG.getMimeType(), IMAGE_PNG.getMimeType(), IMAGE_GIF.getMimeType())
+                   .contains(file.getContentType()))
+            throw InvalidRequestException.builder()
+                                         .message("파일이 이미지가 아닙니다.")
+                                         .invalidValue("파일 유형: " + file.getContentType())
+                                         .code("U402")
+                                         .build();
+    }
+}


### PR DESCRIPTION
## 🎵 설명
: ProfileUtil 생성해서 이미지의 metadata 뽑는 함수와 이미지인지 확인하는 함수를 분리
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
:
<br>

## 🏷 해결한 이슈 번호 
Fixed: #245
<br>

## 📌 Merge 제목
`Merge: develop <- `브랜치명 #pr번호
