### PR TITLE
뉴스 도메인 관련 테스트 코드의 참조 위치 수정

### DIFF
--- a/src/test/java/com/teamharmony/newscommunity/news/controller/NewsControllerTest.java
+++ b/src/test/java/com/teamharmony/newscommunity/news/controller/NewsControllerTest.java
@@ -2,11 +2,11 @@ package com.teamharmony.newscommunity.news.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.teamharmony.newscommunity.common.ApiResponse;
-import com.teamharmony.newscommunity.news.dto.NewsDetailResponseDto;
-import com.teamharmony.newscommunity.news.entity.NewsTable;
-import com.teamharmony.newscommunity.news.service.NewsService;
-import com.teamharmony.newscommunity.auth.repository.TokensRepository;
+import com.teamharmony.newscommunity.domain.auth.repository.TokensRepository;
+import com.teamharmony.newscommunity.domain.news.controller.NewsController;
+import com.teamharmony.newscommunity.domain.news.dto.NewsDetailResponseDto;
+import com.teamharmony.newscommunity.domain.news.entity.NewsTable;
+import com.teamharmony.newscommunity.domain.news.service.NewsService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -27,19 +27,6 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-//1.  퓨어 자바, 테스트 먼저 보기 => 어떻게? => junit 거의 쓰긴 하지만, 프레임 워크보다 테스트에 대한 것부터 이해
-// ex) 단위, 기능 인수 테스트 등 --, 테스트 왜 해야 되는지에 대해 이해
-// 책, 강의 추천: 백기선(장기적으로, 시간 투자): https://www.inflearn.com/course/the-java-application-test#curriculum,
-
-//2.  스프링의 구조? => 목 객체 이해를 위해 필요  => 어떻게 공부해? => 스프링 컨테이너, 빈, 의존성주입,
-//3.  JPA는 김영한니 ㅁ책
-
-// 1. 테스트 코드 디버깅??
-// 2. NewsMockConfig 나누는법?
-// 3.인코딩이 이상하게 돼
-// .addFilters(new CharacterEncodingFilter("UTF-8", true))
-
-
 
 @EnableMockMvc
 @MockBean(JpaMetamodelMappingContext.class)
@@ -57,9 +44,6 @@ class NewsControllerTest {
 
     @MockBean
     NewsService newsService;
-    @MockBean
-    ApiResponse apiResponse;
-
 
     @Test
     @DisplayName("getNewsDetailTest() Connect")

--- a/src/test/java/com/teamharmony/newscommunity/news/service/NewsServiceTest.java
+++ b/src/test/java/com/teamharmony/newscommunity/news/service/NewsServiceTest.java
@@ -1,11 +1,12 @@
 package com.teamharmony.newscommunity.news.service;
 
-import com.teamharmony.newscommunity.news.dto.CreateNewsAccessLogRequestDto;
-import com.teamharmony.newscommunity.news.dto.NewsDetailResponseDto;
-import com.teamharmony.newscommunity.news.entity.NewsAccessLog;
-import com.teamharmony.newscommunity.news.entity.NewsTable;
-import com.teamharmony.newscommunity.news.repository.NewsAccessLogRepository;
-import com.teamharmony.newscommunity.news.repository.NewsRepository;
+import com.teamharmony.newscommunity.domain.news.dto.CreateNewsAccessLogRequestDto;
+import com.teamharmony.newscommunity.domain.news.dto.NewsDetailResponseDto;
+import com.teamharmony.newscommunity.domain.news.entity.NewsAccessLog;
+import com.teamharmony.newscommunity.domain.news.entity.NewsTable;
+import com.teamharmony.newscommunity.domain.news.repository.NewsAccessLogRepository;
+import com.teamharmony.newscommunity.domain.news.repository.NewsRepository;
+import com.teamharmony.newscommunity.domain.news.service.NewsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,17 +29,23 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
+
+/**
+ * NewsService에 대한 서비스 계층의 테스트코드
+ * @author hyoeKing
+ */
 @ExtendWith(MockitoExtension.class)
 class NewsServiceTest {
 
     @Nested
     @DisplayName("뉴스 접근 기록 관련 테스트")
     class NewsAccessTest {
-        @Mock                                                       // 레포지 토리 직접 접근을 막기 위해, 목 객체로 주입받아 사용
+        @Mock                                                            // 레포지 토리 직접 접근을 막기 위해, 목 객체로 주입받아 사용
         private NewsAccessLogRepository newsAccessLogRepository;         // newsAccess관련 서비스를 위한 레포지토리
 
-        @InjectMocks                                                // 목을 주입받아 사용할 service 등록
+        @InjectMocks                                                    // 목을 주입받아 사용할 service 등록
         private NewsService newsService;                                // 뉴스 접근 기록 생성, 조회수 증가 및 뉴스 정보 listing등의 기능을 하는 서비스
+
 
         @Test
         @DisplayName("뉴스 접근 기록 생성 테스트")
@@ -56,6 +63,7 @@ class NewsServiceTest {
             assertEquals(expected.getNews_id(), actual);
         }
     }
+
 
     @Nested
     @DisplayName("뉴스 정보 관련 테스트")
@@ -106,12 +114,13 @@ class NewsServiceTest {
             assertEquals(actual.getImage_url(), expect.getImage_url());
         }
 
+
         @DisplayName("뉴스 정보 일괄 조회 테스트")
         @Test
         void getNews(){
-            doReturn(newsList()).when(newsRepository).findAll();                // 1. given: newsRepository에서 findall을 호출시, 아래 newsList()를 통해 생성된 List<newsTable>이 반환되도록
-            final List<NewsDetailResponseDto> expect = newsService.getNews();               // 2. when:  newsService의 getNews()가 호출되었을 때, 나온 ResponseNewsDTO값을 expect에 할당
-            assertThat(expect.size()).isEqualTo(5); // 3. Then:   expect의 크기가 5인지(예상하는 리스트 크기(5)) 확인
+            doReturn(newsList()).when(newsRepository).findAll();                             // 1. given: newsRepository에서 findall을 호출시, 아래 newsList()를 통해 생성된 List<newsTable>이 반환되도록
+            final List<NewsDetailResponseDto> expect = newsService.getNews();                // 2. when:  newsService의 getNews()가 호출되었을 때, 나온 ResponseNewsDTO값을 expect에 할당
+            assertThat(expect.size()).isEqualTo(5);                                 // 3. Then:   expect의 크기가 5인지(예상하는 리스트 크기(5)) 확인
         }
         private List<NewsTable> newsList() {
             // 위 getNews() 테스트에서 사용할 newsTableList를 만들기 위한 함수


### PR DESCRIPTION
## 🎵 설명
: 뉴스 도메인의 폴더 위치가 domain의 하위로 수정되었는데, 테스트코드는 해당 리팩토링이 적용되지 않아 직접 수정 필요
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: 네이밍과 관련된 리팩토링은 테스트 코드에는 적용되지 않는 이슈
<br>

## 🏷 해결한 이슈 번호 
Fixed: #252 
<br>

## 📌 Merge 제목
`Merge: develop <- `252/fix_news-test-path-check #253
