### PR TITLE
uuid를 pk로 사용하는 도메인에 인덱싱

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/domain/bookmarks/entity/Bookmarks.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/bookmarks/entity/Bookmarks.java
@@ -6,15 +6,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.util.UUID;
 
 @Data
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Table(indexes = @Index(name= "u_NewsId", columnList = "id"))
 public class Bookmarks extends TimestampedOnBookmark {
     @Id
     @Column(nullable = false, unique = true, length = 60)

--- a/src/main/java/com/teamharmony/newscommunity/domain/news/entity/NewsAccessLog.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/news/entity/NewsAccessLog.java
@@ -4,9 +4,7 @@ import com.teamharmony.newscommunity.common.util.TimestampedOnLog;
 import com.teamharmony.newscommunity.domain.news.dto.CreateNewsAccessLogRequestDto;
 import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.util.UUID;
 
 
@@ -19,6 +17,7 @@ import java.util.UUID;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Table(indexes = @Index(name= "u_NewsId", columnList = "id"))
 public class NewsAccessLog extends TimestampedOnLog {
     @Id
     @Column(nullable = false)

--- a/src/main/java/com/teamharmony/newscommunity/domain/news/entity/NewsTable.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/news/entity/NewsTable.java
@@ -1,24 +1,20 @@
 package com.teamharmony.newscommunity.domain.news.entity;
 
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 
 /**
  * 파이썬 뉴스 정보 관리 외부 모듈로부터 RDS에 저장된 NewsTable을 연동하기 위한 엔티티
  * @Author hyeoKing
  */
-@Setter @Getter
+@Getter @Setter //  NewsServiceTest 테스트 코드에서 의도적 값 수정을 위해 어쩔 수 없이 Setter 추가
 @NoArgsConstructor
 @Entity
-@AllArgsConstructor
+@Table(indexes = @Index(name= "u_NewsId", columnList = "id"))
 public class NewsTable {
     @Id
     @Column(nullable = false, unique = true, length = 30)
@@ -47,5 +43,16 @@ public class NewsTable {
 
     public void updateView() {this.view += 1;}  // DB에 대한 조회수 증가 요청을 처리할 함수
 
+    @Builder
+    public NewsTable(String id, String title, String summary, String image_url, String news_url, String explains, String write_time, Long view){
+        this.id = id;
+        this.title = title;
+        this.summary = summary;
+        this.image_url = image_url;
+        this.news_url = news_url;
+        this.explains = explains;
+        this.write_time = write_time;
+        this.view = view;
+    }
 }
 

--- a/src/test/java/com/teamharmony/newscommunity/news/service/NewsServiceTest.java
+++ b/src/test/java/com/teamharmony/newscommunity/news/service/NewsServiceTest.java
@@ -74,7 +74,16 @@ class NewsServiceTest {
         private NewsRepository newsRepository;
         @InjectMocks
         private NewsService newsService;
-        private NewsTable newsTable = new NewsTable("test-uuid", "테스트 제목", "테스트 요약", "테스트 이미지주소", "테스트 뉴스 주소", "테스트 설명", "테스트작성 시간", 1L);
+        private NewsTable newsTable = NewsTable.builder()
+                .id("test-uuid")
+                .title("테스트 제목")
+                .summary("테스트 요약")
+                .image_url("테스트 이미지주소")
+                .news_url("테스트 뉴스 주소")
+                .explains("테스트 설명")
+                .write_time("테스트작성 시간")
+                .view(1L)
+                .build();
         @BeforeEach
         void setup() {
             newsTable.setId("test-uuid");


### PR DESCRIPTION
## 🎵 설명
:  uuid를 pk로 사용하면 full scan이 발생해 처리 속도의 불이익 발생, 이러한 문제 해결을 위해 인덱싱 적용
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: uuid를 썼을 때 full scan이 발생하는 이유, 이를 해결하는 방법에 대한 논의
<br>

## 🏷 해결한 이슈 번호 
Fixed: #257 
<br>

## 📌 Merge 제목
`Merge: develop <- `257/feat_indexing-4-uuid #260
