### PR TITLE
@ManyToOne 쓰는 Entity FetchType.LAZY로 수정

### DIFF
--- a/src/main/java/com/teamharmony/newscommunity/domain/comments/entity/Comment.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/comments/entity/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends Timestamped {
     private String newsId;
 
     @JsonManagedReference
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/teamharmony/newscommunity/domain/comments/entity/Likes.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/comments/entity/Likes.java
@@ -21,12 +21,12 @@ public class Likes {
     private Long id;
 
     @JsonManagedReference
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @JsonManagedReference
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
 

--- a/src/main/java/com/teamharmony/newscommunity/domain/supports/entity/Support.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/supports/entity/Support.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import javax.persistence.*;
 
+import org.hibernate.annotations.Fetch;
+
 @Setter
 @Getter
 @NoArgsConstructor
@@ -34,7 +36,7 @@ public class Support extends Timestamped {
 
 
     @JsonManagedReference
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/teamharmony/newscommunity/domain/users/entity/UserRole.java
+++ b/src/main/java/com/teamharmony/newscommunity/domain/users/entity/UserRole.java
@@ -13,11 +13,11 @@ public class UserRole {
 	@Id
 	private Long id;
 	@JsonIgnore
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name="user_id")
 	private User user;
 	@JsonIgnore
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "role_id")
 	private Role role;
 	


### PR DESCRIPTION

## 🎵 설명
: 엔티티 조회 쿼리 성능을 향상을 위해 @ManyToOne으로 묶인 엔티티들 FetchType.LAZY로 적용 
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
:
<br>

## 🏷 해결한 이슈 번호 
Fixed: #278 
<br>

## 📌 Merge 제목
`Merge: develop <- `브랜치명 #pr번호
