### PR TITLE
Fix: application.properties에서 DB를 RDS 주소에서 로컬 주소로 변경

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=jdbc:mysql://database-1.cpimcopk2kqb.ap-northeast-2.rds.amazonaws.com:3306/harmony
-spring.datasource.username=admin
-spring.datasource.password=sparta12#$
+spring.datasource.url=jdbc:mysql://localhost:3306/harmony
+spring.datasource.username=
+spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
 spring.mvc.pathmatch.matching-strategy = ant_path_matcher
 


### PR DESCRIPTION
## 🎵 설명
:  RDS 인스턴스가 삭제되어서 차후 프로젝트 수정시 로컬 DB를 사용해야되기 때문에 로컬 DB 주소로 application.properties를 수정
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
:
<br>

## 🏷 해결한 이슈 번호 
Fixed: #280 
<br>

## 📌 Merge 제목
`Merge: develop <- `브랜치명 #pr번호
